### PR TITLE
Support reading rpm version and release number from properties

### DIFF
--- a/maven-plugin/src/main/java/org/kantega/reststop/maven/dist/AbstractDistMojo.java
+++ b/maven-plugin/src/main/java/org/kantega/reststop/maven/dist/AbstractDistMojo.java
@@ -86,6 +86,12 @@ public abstract class AbstractDistMojo extends AbstractReststopMojo {
     @Parameter(defaultValue = "${project.artifactId}")
     protected String name;
 
+    @Parameter(defaultValue = "${project.version}")
+    protected String version;
+
+    @Parameter(defaultValue = "1")
+    protected String release;
+
     @Parameter(defaultValue = "/")
     protected String contextPath;
 

--- a/maven-plugin/src/main/java/org/kantega/reststop/maven/dist/RpmBuilder.java
+++ b/maven-plugin/src/main/java/org/kantega/reststop/maven/dist/RpmBuilder.java
@@ -123,7 +123,7 @@ public class RpmBuilder extends AbstractDistMojo {
             String installDir = trimBothEnds(this.installDir,"/");
             pw.println("Name: " + name);
             pw.println("Version: " + safeVersion());
-            pw.println("Release: 1");
+            pw.println("Release: " + release);
             pw.println("Summary: " + mavenProject.getDescription());
             pw.println("License: Unknown");
             pw.println("Group: Webapps/Java");
@@ -211,7 +211,7 @@ public class RpmBuilder extends AbstractDistMojo {
     }
 
     private String safeVersion() {
-        return mavenProject.getVersion().replace('-', '.');
+        return version.replace('-', '.');
     }
 
 }


### PR DESCRIPTION
This makes sense in a continuous deployment scenario, where you would set the
rpm version and release from the build system instead of doing regular maven
releases for each build.

Example usage:

    <properties>
        <version>${project.version}</version>
        <release>1</release>
    </properties>
    <build>
        <plugins>
            <plugin>
                <groupId>org.kantega.reststop</groupId>
                <artifactId>reststop-maven-plugin</artifactId>
                <version>${reststop.version}</version>
                <configuration>
                    <version>${version}</version>
                    <release>${release}</release>
                    ...
                </configuration
            </plugin>

$ mvn -Dversion=623 -Drelease=4 org.kantega.reststop:reststop-maven-plugin:1.12-SNAPSHOT:dist-rpm

...

[INFO] rpmbuild: Wrote: /.../webapp/target/reststop/rpm/RPMS/noarch/webapp-623-4.noarch.rpm

Version and release default to ${project.version} and 1, respectively, if not
entered into the <configuration> section.