### PR TITLE
DD-757 GHA workflow_dispatch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+root = true
+[*]
+insert_final_newline = true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,10 @@
+name: CI
+on:
+  workflow_dispatch:
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: First test
+        run: |
+          echo: this is a test.


### PR DESCRIPTION
For å senere publisere maven-artifakt.
Laster opp workflow_dispatch for å kunne trigge flyten manuelt fra branch.